### PR TITLE
Activate FireCSS for Firefox 4

### DIFF
--- a/public/firecss@webspeed.co.nz/install.rdf
+++ b/public/firecss@webspeed.co.nz/install.rdf
@@ -10,7 +10,7 @@
       <Description>
         <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
         <em:minVersion>2.0</em:minVersion>
-        <em:maxVersion>4.0b8pre</em:maxVersion>
+        <em:maxVersion>4.*</em:maxVersion>
       </Description>
     </em:targetApplication>
      <!-- Firebug extension -->


### PR DESCRIPTION
FireCSS works with Firefox 4 and Firebug 1.7. The only thing to change is the maxVersion
