### PR TITLE
Issue in download function when HTML file hasn't doctype

### DIFF
--- a/public/firecss@webspeed.co.nz/chrome/content/firecss/firecss.js
+++ b/public/firecss@webspeed.co.nz/chrome/content/firecss/firecss.js
@@ -325,8 +325,19 @@ FBL.ns(function() {
                 var html = content.document.createElement("input");
                 html.setAttribute("type", 'hidden');
                 html.setAttribute("name", 'html');
-                var docContent = '<!DOCTYPE ' + content.document.doctype.name + ' PUBLIC "'+ content.document.doctype.publicId + '" "' + content.document.doctype.systemId + '">\n'
-                docContent += '<html'
+                // test if document has doctype before use it
+                if (content.document.doctype) {
+                    var docContent = '<!DOCTYPE ' + content.document.doctype.name;
+                    if (content.document.doctype.publicId != '') { // If html5 doctype, content.document.doctype.publicId will be empty
+                        docContent += ' PUBLIC "'+ content.document.doctype.publicId + '" "' + content.document.doctype.systemId + '"';
+                    }
+                    docContent += '>\n';
+                } else {
+                    // no doctype, very dirty code : set a default doctype
+                    // as you are a dirty girl or guy, the default doctype will be HTML 5 !
+                    var docContent = '<!DOCTYPE html>\n';
+                }
+                docContent += '<html';
                 for (var i=0; i < content.document.documentElement.attributes.length; i++) {
                     var attr = content.document.documentElement.attributes[i];
                     docContent+= ' ' + attr.name + '="' + attr.value + '"';

--- a/public/firecss@webspeed.co.nz/install.rdf
+++ b/public/firecss@webspeed.co.nz/install.rdf
@@ -10,7 +10,7 @@
       <Description>
         <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
         <em:minVersion>2.0</em:minVersion>
-        <em:maxVersion>4.0b8pre</em:maxVersion>
+        <em:maxVersion>4.*</em:maxVersion>
       </Description>
     </em:targetApplication>
      <!-- Firebug extension -->


### PR DESCRIPTION
When the HTML file is dirty (because no DOCTYPE), the FireCSS doesn't allow to download modified file. This commit fix the bug
